### PR TITLE
update websocket-object in room.players array when user reconnects

### DIFF
--- a/backend/controllers/websocket.controller.js
+++ b/backend/controllers/websocket.controller.js
@@ -6,7 +6,6 @@ class WebsocketController {
     }
 
 	handleConnection(connection, req, wsid) {
-		console.log("[WebsocketController] handle connection ", wsid );
 
 		this.service.handleJoin(connection, wsid);
 		this.service.handleLeave(connection);

--- a/backend/serviceWs/matchmaking.service.js
+++ b/backend/serviceWs/matchmaking.service.js
@@ -201,6 +201,16 @@ class MatchMakingService {
 		await this.RoomService.destroyRoom(room.id);
 
 	}
+
+
+	async reconnectPlayerToAllRooms(connection) {
+		let rooms = this.RoomService.rooms;
+		for (let r of rooms) {
+			RoomUtilsService.reconnectPlayerToRoom(r, connection);
+		}
+	}
+
+
 }
 
 export default MatchMakingService;

--- a/backend/serviceWs/roomutils.service.js
+++ b/backend/serviceWs/roomutils.service.js
@@ -56,7 +56,7 @@ class RoomUtilsService {
 			if (p.ai == true) {
 				continue ;
 			}
-			if (p.wsclient.userId == connection.userId) {
+			if (p.id == connection.userId) {
 				areUEvenInvitedBro = true;
 				break;
 			}
@@ -85,6 +85,18 @@ class RoomUtilsService {
 			}
 			if (p.accepted != "declined") {
 				await websocketService.sendMessageToClient(p.wsclient, message);
+			}
+		}
+	}
+
+
+	// this method updates the wsclient inside the room.players array after user has reconnected
+	static async reconnectPlayerToRoom(room, connection) {
+		for (let p of room.players) {
+			if (p.id === connection.userId) {
+				p.wsclient = connection;
+				console.log(`[reconnect] reconnected user ${p.id} to room ${room.id}`);
+				break ;
 			}
 		}
 	}

--- a/backend/serviceWs/websocket.service.js
+++ b/backend/serviceWs/websocket.service.js
@@ -16,15 +16,19 @@ class WebsocketService {
 
 	handleJoin(connection, wsid) {
 		connection.userId = wsid;
+		console.log("[WebSocket] user connected ", connection.userId);
 		this.broadcast({
 			type: "BROADCAST",
 			sender: '__server',
 			message: `id ${wsid} joined`
 		}, connection);
-	}
 
+		this.matchMakingService.reconnectPlayerToAllRooms(connection);
+	}
+	
 	handleLeave(connection) {
 		connection.on('close', () => {
+			console.log("[WebSocket] user disconnected ", connection.userId);
 			this.broadcast({
 				type: "BROADCAST",
 				sender: '__server',


### PR DESCRIPTION
closes #108 

this PR handles updating the connection information in the room information.

case 1:
user disconnects and reconnects. this will break the websocket connection. in backend this will create a new ws-connection object.
if the user was part of any rooms, the websocket needs the new connection object to be able to reach the user.

case 2:
user.... reloads the website. this is disconnecting the websocket (currently). 