### PR TITLE
Backend email validation

### DIFF
--- a/backend/plugins/auth-utils.js
+++ b/backend/plugins/auth-utils.js
@@ -122,7 +122,32 @@ export function validatePassword(password) {
 }
 
 export function validateEmail(email) {
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  // More comprehensive email validation
+  const emailRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+  
+  if (!email || typeof email !== 'string') {
+    return false;
+  }
+  
+  if (email.length > 254) {
+    return false;
+  }
+  
+  const localPart = email.split('@')[0];
+  if (localPart.length > 64) {
+    return false;
+  }
+  
+  const parts = email.split('@');
+  if (parts.length !== 2) {
+    return false;
+  }
+  const domainPart = parts[1];
+  if (domainPart.length > 253) {
+    return false;
+  }
+  
+  // Regex validation
   return emailRegex.test(email);
 }
 

--- a/src/components/SettingsPage/index.ts
+++ b/src/components/SettingsPage/index.ts
@@ -5,6 +5,7 @@ import { ErrorManager } from "../Error";
 import { getApiUrl } from "../../config/api";
 import { ConfirmDialogManager } from "../ConfirmDialog";
 import { NicknameUtils } from "../../utils/nickname.utils";
+import { COMMON_TLDS, VALID_COUNTRY_TLDS } from "../../utils/emailTLDs";
 
 interface SettingsPageState {
   currentPage: 'page1' | 'page2' | 'confirm' | 'password_change';
@@ -105,7 +106,7 @@ export class SettingsPage extends Component<SettingsPageState> {
             return false;
         }
         
-        const commonTLDs = ['com', 'org', 'net', 'edu', 'gov', 'mil', 'int'];
+        const commonTLDs = COMMON_TLDS;
         
         // Handle 2-part domains (e.g., example.com)
         if (domainParts.length === 2) {
@@ -122,14 +123,7 @@ export class SettingsPage extends Component<SettingsPageState> {
             const thirdPart = domainParts[2];
             
             // Define valid country TLD combinations
-            const validCountryTLDs = [
-                'co.uk', 'co.us', 'co.ca', 'co.au', 'co.nz', 'co.za', 'co.in', 'co.jp', 'co.kr', 'co.cn',
-                'com.au', 'com.br', 'com.mx', 'com.sg', 'com.hk', 'com.tw', 'com.my', 'com.ph', 'com.th',
-                'org.uk', 'org.au', 'org.nz', 'org.za', 'org.in', 'org.jp', 'org.kr', 'org.cn',
-                'net.uk', 'net.au', 'net.nz', 'net.za', 'net.in', 'net.jp', 'net.kr', 'net.cn',
-                'edu.au', 'edu.nz', 'edu.za', 'edu.in', 'edu.jp', 'edu.kr', 'edu.cn',
-                'gov.uk', 'gov.au', 'gov.nz', 'gov.za', 'gov.in', 'gov.jp', 'gov.kr', 'gov.cn'
-            ];
+            const validCountryTLDs = VALID_COUNTRY_TLDS;
             
             const countryTLD = secondPart + '.' + thirdPart;
             if (validCountryTLDs.includes(countryTLD)) {
@@ -155,14 +149,7 @@ export class SettingsPage extends Component<SettingsPageState> {
             const fourthPart = domainParts[3];
             
             // Define valid country TLD combinations
-            const validCountryTLDs = [
-                'co.uk', 'co.us', 'co.ca', 'co.au', 'co.nz', 'co.za', 'co.in', 'co.jp', 'co.kr', 'co.cn',
-                'com.au', 'com.br', 'com.mx', 'com.sg', 'com.hk', 'com.tw', 'com.my', 'com.ph', 'com.th',
-                'org.uk', 'org.au', 'org.nz', 'org.za', 'org.in', 'org.jp', 'org.kr', 'org.cn',
-                'net.uk', 'net.au', 'net.nz', 'net.za', 'net.in', 'net.jp', 'net.kr', 'net.cn',
-                'edu.au', 'edu.nz', 'edu.za', 'edu.in', 'edu.jp', 'edu.kr', 'edu.cn',
-                'gov.uk', 'gov.au', 'gov.nz', 'gov.za', 'gov.in', 'gov.jp', 'gov.kr', 'gov.cn'
-            ];
+            const validCountryTLDs = VALID_COUNTRY_TLDS;
 
             const lastTwoParts = thirdPart + '.' + fourthPart;
             

--- a/src/components/SettingsPage/index.ts
+++ b/src/components/SettingsPage/index.ts
@@ -189,7 +189,6 @@ export class SettingsPage extends Component<SettingsPageState> {
                    domainPart.length > 0 && 
                    domainPart.includes('.') &&
                    !localPart.startsWith('.') && 
-                   !localPart.startsWith('.') &&
                    !localPart.endsWith('.') &&
                    !domainPart.startsWith('.') && 
                    !domainPart.endsWith('.') &&

--- a/src/components/SettingsPage/index.ts
+++ b/src/components/SettingsPage/index.ts
@@ -40,17 +40,180 @@ export class SettingsPage extends Component<SettingsPageState> {
     super();
   }
 
+    private validateEmail(email: string): boolean {
+        // More comprehensive email validation
+        const emailRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+        
+        if (!email || typeof email !== 'string') {
+            return false;
+        }
+        
+        if (email.length > 254) {
+            return false;
+        }
+        
+        const parts = email.split('@');
+        if (parts.length !== 2) {
+            return false;
+        }
+        
+        const localPart = parts[0];
+        const domainPart = parts[1];
+              
+        if (localPart.length > 64 || localPart.length === 0) {
+            return false;
+        }
+          
+        if (domainPart.length > 253 || domainPart.length === 0) {
+            return false;
+        }
+        
+        if (localPart.startsWith('.') || localPart.endsWith('.')) {
+            return false;
+        }
+        
+        if (localPart.includes('..')) {
+            return false;
+        }
+        
+        if (domainPart.startsWith('.') || domainPart.endsWith('.')) {
+            return false;
+        }
+        
+        if (domainPart.includes('..')) {
+            return false;
+        }
+        
+        if (domainPart.startsWith('-') || domainPart.endsWith('-')) {
+            return false;
+        }
+        
+        const domainParts = domainPart.split('.');
+        if (domainParts.length > 4) {
+            return false;
+        }
+        
+        // Check that no domain part starts or ends with hyphens
+        for (const part of domainParts) {
+            if (part.startsWith('-') || part.endsWith('-')) {
+                return false;
+            }
+        }
+        
+        // Ensure domain has at least one dot (TLD requirement)
+        if (!domainPart.includes('.')) {
+            return false;
+        }
+        
+        const commonTLDs = ['com', 'org', 'net', 'edu', 'gov', 'mil', 'int'];
+        
+        // Handle 2-part domains (e.g., example.com)
+        if (domainParts.length === 2) {
+            const secondPart = domainParts[1];
+            if (!commonTLDs.includes(secondPart)) {
+                return false;
+            }
+            return true;
+        }
+        
+        // Handle 3-part domains (e.g., sub.example.com, example.co.uk)
+        if (domainParts.length === 3) {
+            const secondPart = domainParts[1];
+            const thirdPart = domainParts[2];
+            
+            // Define valid country TLD combinations
+            const validCountryTLDs = [
+                'co.uk', 'co.us', 'co.ca', 'co.au', 'co.nz', 'co.za', 'co.in', 'co.jp', 'co.kr', 'co.cn',
+                'com.au', 'com.br', 'com.mx', 'com.sg', 'com.hk', 'com.tw', 'com.my', 'com.ph', 'com.th',
+                'org.uk', 'org.au', 'org.nz', 'org.za', 'org.in', 'org.jp', 'org.kr', 'org.cn',
+                'net.uk', 'net.au', 'net.nz', 'net.za', 'net.in', 'net.jp', 'net.kr', 'net.cn',
+                'edu.au', 'edu.nz', 'edu.za', 'edu.in', 'edu.jp', 'edu.kr', 'edu.cn',
+                'gov.uk', 'gov.au', 'gov.nz', 'gov.za', 'gov.in', 'gov.jp', 'gov.kr', 'gov.cn'
+            ];
+            
+            const countryTLD = secondPart + '.' + thirdPart;
+            if (validCountryTLDs.includes(countryTLD)) {
+                // This is valid: sub.example.co.uk, example.co.uk
+                return true;
+            }
+            
+            // Reject: example.com.com, example.org.com, example.com.org
+            if (commonTLDs.includes(secondPart) && commonTLDs.includes(thirdPart)) {
+                return false;
+            }
+            
+            if (commonTLDs.includes(thirdPart)) {
+                return true;
+            }
+            
+            return false;
+        }
+        
+        // Handle 4-part domains (e.g., sub.example.co.uk, sub.example.com.au)
+        if (domainParts.length === 4) {
+            const thirdPart = domainParts[2];
+            const fourthPart = domainParts[3];
+            
+            // Define valid country TLD combinations
+            const validCountryTLDs = [
+                'co.uk', 'co.us', 'co.ca', 'co.au', 'co.nz', 'co.za', 'co.in', 'co.jp', 'co.kr', 'co.cn',
+                'com.au', 'com.br', 'com.mx', 'com.sg', 'com.hk', 'com.tw', 'com.my', 'com.ph', 'com.th',
+                'org.uk', 'org.au', 'org.nz', 'org.za', 'org.in', 'org.jp', 'org.kr', 'org.cn',
+                'net.uk', 'net.au', 'net.nz', 'net.za', 'net.in', 'net.jp', 'net.kr', 'net.cn',
+                'edu.au', 'edu.nz', 'edu.za', 'edu.in', 'edu.jp', 'edu.kr', 'edu.cn',
+                'gov.uk', 'gov.au', 'gov.nz', 'gov.za', 'gov.in', 'gov.jp', 'gov.kr', 'gov.cn'
+            ];
+
+            const lastTwoParts = thirdPart + '.' + fourthPart;
+            
+            // If the last two parts form a valid country TLD, this is a valid subdomain
+            if (validCountryTLDs.includes(lastTwoParts)) {
+                return true;
+            }
+            
+            // Check for invalid double TLD patterns in the last three parts
+            if (commonTLDs.includes(thirdPart) && commonTLDs.includes(fourthPart)) {
+                return false;
+            }
+            
+            // Allow valid subdomain patterns where the last part is a TLD
+            if (commonTLDs.includes(fourthPart)) {
+                return true;
+            }
+            
+            return false;
+        }
+        
+        if (email.length > 100) {
+            return localPart.length > 0 && 
+                   domainPart.length > 0 && 
+                   domainPart.includes('.') &&
+                   !localPart.startsWith('.') && 
+                   !localPart.startsWith('.') &&
+                   !localPart.endsWith('.') &&
+                   !domainPart.startsWith('.') && 
+                   !domainPart.endsWith('.') &&
+                   !localPart.includes('..') &&
+                   !domainPart.includes('..') &&
+                   !domainPart.startsWith('-') &&
+                   !domainPart.endsWith('-');
+        }
+        
+        // Regex validation for shorter emails
+        return emailRegex.test(email);
+    }
+
   private showError(message: string) {
     this.setState({
-        showError: true,
-        errorMessage: message
+      showError: true,
+      errorMessage: message
     });
 
     ErrorManager.showError(message, this.element, () => {
-        this.setState({
-            showError: false,
-            errorMessage: null
-        });
+      this.setState({
+        showError: false,
+        errorMessage: null
+      });
     });
   }
 
@@ -175,6 +338,11 @@ export class SettingsPage extends Component<SettingsPageState> {
       const currentEmail = emailInput ? emailInput.value.trim() : '';
       const originalEmail = this.state.originalValues.email || '';
       if (currentEmail !== originalEmail) {
+        // Validate email before adding to pending changes
+        if (!this.validateEmail(currentEmail)) {
+          this.showError('Please enter a valid email address');
+          return;
+        }
         pendingChanges.email = currentEmail;
       }
 
@@ -220,6 +388,11 @@ export class SettingsPage extends Component<SettingsPageState> {
       const currentEmail = emailInput ? emailInput.value.trim() : '';
       const originalEmail = this.state.originalValues.email || '';
       if (currentEmail !== originalEmail) {
+        // Validate email before adding to pending changes
+        if (!this.validateEmail(currentEmail)) {
+          this.showError('Please enter a valid email address');
+          return;
+        }
         pendingChanges.email = currentEmail;
       }
       

--- a/src/components/SettingsPage/template.html
+++ b/src/components/SettingsPage/template.html
@@ -30,7 +30,7 @@
         <img src="/art/settings_page/clouds.svg" alt="clouds" class="absolute top-[42%] left-[49%] transform -translate-x-1/2 -translate-y-1/2 w-[68%] object-contain">
         <form id="settings_form" class="absolute flex flex-col top-[50%] left-[50%] -translate-x-1/2 -translate-y-1/2 w-[70%] h-[50%] p-4">
             <input type="text" id="username" placeholder="Username" class="ml-[56%] mt-[8%] md:mt-[8.5%] lg:mt-[9%] text-[15px] md:text-[18px] focus:outline-none text-[#687274]" maxlength="15" />
-            <input type="text" id="email" placeholder="Email" class="ml-[3%] mt-[18%] md:mt-[18.5%] lg:mt-[19%] text-[15px] md:text-[18px] focus:outline-none text-[#687274] w-[40%]"  maxlength="50"/>
+            <input type="email" id="email" placeholder="Email" class="ml-[3%] mt-[18%] md:mt-[18.5%] lg:mt-[19%] text-[15px] md:text-[18px] focus:outline-none text-[#687274] w-[40%]"  maxlength="254"/>
             <button id="confirm_button_page1"
             class="absolute top-[50%] right-[5%]  cursor-pointer hover:opacity-80 transition-opacity duration-300"
             >

--- a/src/components/SignInPage/index.ts
+++ b/src/components/SignInPage/index.ts
@@ -50,11 +50,191 @@ export class SignInPage extends Component<SignInPageState> {
         });
     }
 
+    private validateEmail(email: string): boolean {
+        // More comprehensive email validation
+        const emailRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+        
+        if (!email || typeof email !== 'string') {
+            return false;
+        }
+        
+        if (email.length > 254) {
+            return false;
+        }
+        
+        const parts = email.split('@');
+        if (parts.length !== 2) {
+            return false;
+        }
+        
+        const localPart = parts[0];
+        const domainPart = parts[1];
+        
+        // Local part validation (max 64 characters)
+        if (localPart.length > 64 || localPart.length === 0) {
+            return false;
+        }
+        
+        // Domain part validation (max 253 characters)
+        if (domainPart.length > 253 || domainPart.length === 0) {
+            return false;
+        }
+        
+        // Check for leading/trailing dots in local part
+        if (localPart.startsWith('.') || localPart.endsWith('.')) {
+            return false;
+        }
+        
+        // Check for consecutive dots in local part
+        if (localPart.includes('..')) {
+            return false;
+        }
+        
+        // Check for leading/trailing dots in domain part
+        if (domainPart.startsWith('.') || domainPart.endsWith('.')) {
+            return false;
+        }
+        
+        // Check for consecutive dots in domain part
+        if (domainPart.includes('..')) {
+            return false;
+        }
+        
+        // Check for leading/trailing hyphens in domain part
+        if (domainPart.startsWith('-') || domainPart.endsWith('-')) {
+            return false;
+        }
+        
+        const domainParts = domainPart.split('.');
+        if (domainParts.length > 4) {
+            return false;
+        }
+        
+        // Check that no domain part starts or ends with hyphens
+        for (const part of domainParts) {
+            if (part.startsWith('-') || part.endsWith('-')) {
+                return false;
+            }
+        }
+        
+        // Ensure domain has at least one dot (TLD requirement)
+        if (!domainPart.includes('.')) {
+            return false;
+        }
+        
+        const commonTLDs = ['com', 'org', 'net', 'edu', 'gov', 'mil', 'int'];
+        
+        // Handle 2-part domains (e.g., example.com)
+        if (domainParts.length === 2) {
+            const secondPart = domainParts[1];
+            // Check if the second part is a valid TLD
+            if (!commonTLDs.includes(secondPart)) {
+                return false;
+            }
+            return true;
+        }
+        
+        // Handle 3-part domains (e.g., sub.example.com, example.co.uk)
+        if (domainParts.length === 3) {
+            const secondPart = domainParts[1];
+            const thirdPart = domainParts[2];
+            
+            // Define valid country TLD combinations
+            const validCountryTLDs = [
+                'co.uk', 'co.us', 'co.ca', 'co.au', 'co.nz', 'co.za', 'co.in', 'co.jp', 'co.kr', 'co.cn',
+                'com.au', 'com.br', 'com.mx', 'com.sg', 'com.hk', 'com.tw', 'com.my', 'com.ph', 'com.th',
+                'org.uk', 'org.au', 'org.nz', 'org.za', 'org.in', 'org.jp', 'org.kr', 'org.cn',
+                'net.uk', 'net.au', 'net.nz', 'net.za', 'net.in', 'net.jp', 'net.kr', 'net.cn',
+                'edu.au', 'edu.nz', 'edu.za', 'edu.in', 'edu.jp', 'edu.kr', 'edu.cn',
+                'gov.uk', 'gov.au', 'gov.nz', 'gov.za', 'gov.in', 'gov.jp', 'gov.kr', 'gov.cn'
+            ];
+            
+            // This should be checked FIRST to allow both example.co.uk and sub.example.co.uk
+            const countryTLD = secondPart + '.' + thirdPart;
+            if (validCountryTLDs.includes(countryTLD)) {
+                // This is valid: sub.example.co.uk, example.co.uk
+                return true;
+            }
+        
+            // Reject: example.com.com, example.org.com, example.com.org
+            if (commonTLDs.includes(secondPart) && commonTLDs.includes(thirdPart)) {
+                return false;
+            }
+            
+            // Allow valid subdomain patterns: sub.example.com, mail.example.org
+            if (commonTLDs.includes(thirdPart)) {
+                return true;
+            }
+            
+            return false;
+        }
+        
+        // Handle 4-part domains (e.g., sub.example.co.uk, sub.example.com.au)
+        if (domainParts.length === 4) {
+            const thirdPart = domainParts[2];
+            const fourthPart = domainParts[3];
+            
+            // Define valid country TLD combinations
+            const validCountryTLDs = [
+                'co.uk', 'co.us', 'co.ca', 'co.au', 'co.nz', 'co.za', 'co.in', 'co.jp', 'co.kr', 'co.cn',
+                'com.au', 'com.br', 'com.mx', 'com.sg', 'com.hk', 'com.tw', 'com.my', 'com.ph', 'com.th',
+                'org.uk', 'org.au', 'org.nz', 'org.za', 'org.in', 'org.jp', 'org.kr', 'org.cn',
+                'net.uk', 'net.au', 'net.nz', 'net.za', 'net.in', 'net.jp', 'net.kr', 'net.cn',
+                'edu.au', 'edu.nz', 'edu.za', 'edu.in', 'edu.jp', 'edu.kr', 'edu.cn',
+                'gov.uk', 'gov.au', 'gov.nz', 'gov.za', 'gov.in', 'gov.jp', 'gov.kr', 'gov.cn'
+            ];
+            
+            // Check if the last three parts form a valid pattern: example.co.uk
+            
+            const lastTwoParts = thirdPart + '.' + fourthPart;
+            
+            // If the last two parts form a valid country TLD, this is a valid subdomain
+            if (validCountryTLDs.includes(lastTwoParts)) {
+                return true;
+            }
+            
+            // Check for invalid double TLD patterns in the last three parts
+            if (commonTLDs.includes(thirdPart) && commonTLDs.includes(fourthPart)) {
+                return false;
+            }
+            
+            // Allow valid subdomain patterns where the last part is a TLD
+            if (commonTLDs.includes(fourthPart)) {
+                return true;
+            }
+            
+            return false;
+        }
+        
+        if (email.length > 100) {
+            return localPart.length > 0 && 
+                   domainPart.length > 0 && 
+                   domainPart.includes('.') &&
+                   !localPart.startsWith('.') && 
+                   !localPart.startsWith('.') &&
+                   !localPart.endsWith('.') &&
+                   !domainPart.startsWith('.') && 
+                   !domainPart.endsWith('.') &&
+                   !localPart.includes('..') &&
+                   !domainPart.includes('..') &&
+                   !domainPart.startsWith('-') &&
+                   !domainPart.endsWith('-');
+        }
+        
+        // Regex validation for shorter emails
+        return emailRegex.test(email);
+    }
+
     public async handleSignIn(e: Event) {
         e.preventDefault();
         
         if (!this.state.email || !this.state.password) {
             this.showError('Please enter both email and password');
+            return;
+        }
+
+        if (!this.validateEmail(this.state.email)) {
+            this.showError('Please enter a valid email address');
             return;
         }
 

--- a/src/components/SignInPage/index.ts
+++ b/src/components/SignInPage/index.ts
@@ -211,7 +211,6 @@ export class SignInPage extends Component<SignInPageState> {
                    domainPart.length > 0 && 
                    domainPart.includes('.') &&
                    !localPart.startsWith('.') && 
-                   !localPart.startsWith('.') &&
                    !localPart.endsWith('.') &&
                    !domainPart.startsWith('.') && 
                    !domainPart.endsWith('.') &&

--- a/src/components/SignInPage/index.ts
+++ b/src/components/SignInPage/index.ts
@@ -2,6 +2,7 @@ import { Component } from "@blitz-ts/Component";
 import { Router } from "@blitz-ts/router";
 import { ErrorManager } from "../Error";
 import { authService } from "../../lib/auth";
+import { COMMON_TLDS, VALID_COUNTRY_TLDS } from "../../utils/emailTLDs";
 
 interface SignInPageState {
     email: string;
@@ -122,13 +123,11 @@ export class SignInPage extends Component<SignInPageState> {
             return false;
         }
         
-        const commonTLDs = ['com', 'org', 'net', 'edu', 'gov', 'mil', 'int'];
-        
         // Handle 2-part domains (e.g., example.com)
         if (domainParts.length === 2) {
             const secondPart = domainParts[1];
             // Check if the second part is a valid TLD
-            if (!commonTLDs.includes(secondPart)) {
+            if (!COMMON_TLDS.includes(secondPart)) {
                 return false;
             }
             return true;
@@ -140,14 +139,7 @@ export class SignInPage extends Component<SignInPageState> {
             const thirdPart = domainParts[2];
             
             // Define valid country TLD combinations
-            const validCountryTLDs = [
-                'co.uk', 'co.us', 'co.ca', 'co.au', 'co.nz', 'co.za', 'co.in', 'co.jp', 'co.kr', 'co.cn',
-                'com.au', 'com.br', 'com.mx', 'com.sg', 'com.hk', 'com.tw', 'com.my', 'com.ph', 'com.th',
-                'org.uk', 'org.au', 'org.nz', 'org.za', 'org.in', 'org.jp', 'org.kr', 'org.cn',
-                'net.uk', 'net.au', 'net.nz', 'net.za', 'net.in', 'net.jp', 'net.kr', 'net.cn',
-                'edu.au', 'edu.nz', 'edu.za', 'edu.in', 'edu.jp', 'edu.kr', 'edu.cn',
-                'gov.uk', 'gov.au', 'gov.nz', 'gov.za', 'gov.in', 'gov.jp', 'gov.kr', 'gov.cn'
-            ];
+            const validCountryTLDs = VALID_COUNTRY_TLDS;
             
             // This should be checked FIRST to allow both example.co.uk and sub.example.co.uk
             const countryTLD = secondPart + '.' + thirdPart;
@@ -157,12 +149,12 @@ export class SignInPage extends Component<SignInPageState> {
             }
         
             // Reject: example.com.com, example.org.com, example.com.org
-            if (commonTLDs.includes(secondPart) && commonTLDs.includes(thirdPart)) {
+            if (COMMON_TLDS.includes(secondPart) && COMMON_TLDS.includes(thirdPart)) {
                 return false;
             }
             
             // Allow valid subdomain patterns: sub.example.com, mail.example.org
-            if (commonTLDs.includes(thirdPart)) {
+            if (COMMON_TLDS.includes(thirdPart)) {
                 return true;
             }
             
@@ -175,14 +167,7 @@ export class SignInPage extends Component<SignInPageState> {
             const fourthPart = domainParts[3];
             
             // Define valid country TLD combinations
-            const validCountryTLDs = [
-                'co.uk', 'co.us', 'co.ca', 'co.au', 'co.nz', 'co.za', 'co.in', 'co.jp', 'co.kr', 'co.cn',
-                'com.au', 'com.br', 'com.mx', 'com.sg', 'com.hk', 'com.tw', 'com.my', 'com.ph', 'com.th',
-                'org.uk', 'org.au', 'org.nz', 'org.za', 'org.in', 'org.jp', 'org.kr', 'org.cn',
-                'net.uk', 'net.au', 'net.nz', 'net.za', 'net.in', 'net.jp', 'net.kr', 'net.cn',
-                'edu.au', 'edu.nz', 'edu.za', 'edu.in', 'edu.jp', 'edu.kr', 'edu.cn',
-                'gov.uk', 'gov.au', 'gov.nz', 'gov.za', 'gov.in', 'gov.jp', 'gov.kr', 'gov.cn'
-            ];
+            const validCountryTLDs = VALID_COUNTRY_TLDS;
             
             // Check if the last three parts form a valid pattern: example.co.uk
             
@@ -194,12 +179,12 @@ export class SignInPage extends Component<SignInPageState> {
             }
             
             // Check for invalid double TLD patterns in the last three parts
-            if (commonTLDs.includes(thirdPart) && commonTLDs.includes(fourthPart)) {
+            if (COMMON_TLDS.includes(thirdPart) && COMMON_TLDS.includes(fourthPart)) {
                 return false;
             }
             
             // Allow valid subdomain patterns where the last part is a TLD
-            if (commonTLDs.includes(fourthPart)) {
+            if (COMMON_TLDS.includes(fourthPart)) {
                 return true;
             }
             

--- a/src/components/SignUpPage/index.ts
+++ b/src/components/SignUpPage/index.ts
@@ -2,6 +2,7 @@ import { Component } from "@blitz-ts/Component";
 import { Router } from "@blitz-ts/router";
 import { ErrorManager } from "../Error";
 import { authService } from "../../lib/auth";
+import { COMMON_TLDS, VALID_COUNTRY_TLDS } from "../../utils/emailTLDs";
 
 interface SignUpPageState {
     email: string;
@@ -118,7 +119,7 @@ export class SignUpPage extends Component<SignUpPageState> {
             return false;
         }
         
-        const commonTLDs = ['com', 'org', 'net', 'edu', 'gov', 'mil', 'int'];
+        const commonTLDs = COMMON_TLDS;
         
         // Handle 2-part domains (e.g., example.com)
         if (domainParts.length === 2) {
@@ -136,14 +137,7 @@ export class SignUpPage extends Component<SignUpPageState> {
             const thirdPart = domainParts[2];
             
             // Define valid country TLD combinations
-            const validCountryTLDs = [
-                'co.uk', 'co.us', 'co.ca', 'co.au', 'co.nz', 'co.za', 'co.in', 'co.jp', 'co.kr', 'co.cn',
-                'com.au', 'com.br', 'com.mx', 'com.sg', 'com.hk', 'com.tw', 'com.my', 'com.ph', 'com.th',
-                'org.uk', 'org.au', 'org.nz', 'org.za', 'org.in', 'org.jp', 'org.kr', 'org.cn',
-                'net.uk', 'net.au', 'net.nz', 'net.za', 'net.in', 'net.jp', 'net.kr', 'net.cn',
-                'edu.au', 'edu.nz', 'edu.za', 'edu.in', 'edu.jp', 'edu.kr', 'edu.cn',
-                'gov.uk', 'gov.au', 'gov.nz', 'gov.za', 'gov.in', 'gov.jp', 'gov.kr', 'gov.cn'
-            ];
+            const validCountryTLDs = VALID_COUNTRY_TLDS;
             
             // This should be checked FIRST to allow both example.co.uk and sub.example.co.uk
             const countryTLD = secondPart + '.' + thirdPart;
@@ -171,14 +165,7 @@ export class SignUpPage extends Component<SignUpPageState> {
             const fourthPart = domainParts[3];
             
             // Define valid country TLD combinations
-            const validCountryTLDs = [
-                'co.uk', 'co.us', 'co.ca', 'co.au', 'co.nz', 'co.za', 'co.in', 'co.jp', 'co.kr', 'co.cn',
-                'com.au', 'com.br', 'com.mx', 'com.sg', 'com.hk', 'com.tw', 'com.my', 'com.ph', 'com.th',
-                'org.uk', 'org.au', 'org.nz', 'org.za', 'org.in', 'org.jp', 'org.kr', 'org.cn',
-                'net.uk', 'net.au', 'net.nz', 'net.za', 'net.in', 'net.jp', 'net.kr', 'net.cn',
-                'edu.au', 'edu.nz', 'edu.za', 'edu.in', 'edu.jp', 'edu.kr', 'edu.cn',
-                'gov.uk', 'gov.au', 'gov.nz', 'gov.za', 'gov.in', 'gov.jp', 'gov.kr', 'gov.cn'
-            ];
+            const validCountryTLDs = VALID_COUNTRY_TLDS;
 
             const lastTwoParts = thirdPart + '.' + fourthPart;
             

--- a/src/components/SignUpPage/index.ts
+++ b/src/components/SignUpPage/index.ts
@@ -214,7 +214,8 @@ export class SignUpPage extends Component<SignUpPageState> {
                    !domainPart.endsWith('-');
         }
         
-        // Regex validation for shorter emails
+        
+        // Regex validation for emails
         return emailRegex.test(email);
     }
 

--- a/src/components/SignUpPage/index.ts
+++ b/src/components/SignUpPage/index.ts
@@ -47,7 +47,174 @@ export class SignUpPage extends Component<SignUpPageState> {
     }
 
     private validateEmail(email: string): boolean {
-        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        // More comprehensive email validation
+        const emailRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+        
+        if (!email || typeof email !== 'string') {
+            return false;
+        }
+        
+        if (email.length > 254) {
+            return false;
+        }
+        
+        const parts = email.split('@');
+        if (parts.length !== 2) {
+            return false;
+        }
+        
+        const localPart = parts[0];
+        const domainPart = parts[1];
+        
+        // Local part validation (max 64 characters)
+        if (localPart.length > 64 || localPart.length === 0) {
+            return false;
+        }
+        
+        // Domain part validation (max 253 characters)
+        if (domainPart.length > 253 || domainPart.length === 0) {
+            return false;
+        }
+        
+        // Check for leading/trailing dots in local part
+        if (localPart.startsWith('.') || localPart.endsWith('.')) {
+            return false;
+        }
+        
+        // Check for consecutive dots in local part
+        if (localPart.includes('..')) {
+            return false;
+        }
+        
+        // Check for leading/trailing dots in domain part
+        if (domainPart.startsWith('.') || domainPart.endsWith('.')) {
+            return false;
+        }
+        
+        // Check for consecutive dots in domain part
+        if (domainPart.includes('..')) {
+            return false;
+        }
+        
+        // Check for leading/trailing hyphens in domain part
+        if (domainPart.startsWith('-') || domainPart.endsWith('-')) {
+            return false;
+        }
+        
+        const domainParts = domainPart.split('.');
+        if (domainParts.length > 4) {
+            return false;
+        }
+        
+        // Check that no domain part starts or ends with hyphens
+        for (const part of domainParts) {
+            if (part.startsWith('-') || part.endsWith('-')) {
+                return false;
+            }
+        }
+        
+        // Ensure domain has at least one dot (TLD requirement)
+        if (!domainPart.includes('.')) {
+            return false;
+        }
+        
+        const commonTLDs = ['com', 'org', 'net', 'edu', 'gov', 'mil', 'int'];
+        
+        // Handle 2-part domains (e.g., example.com)
+        if (domainParts.length === 2) {
+            const secondPart = domainParts[1];
+            // Check if the second part is a valid TLD
+            if (!commonTLDs.includes(secondPart)) {
+                return false;
+            }
+            return true;
+        }
+        
+        // Handle 3-part domains (e.g., sub.example.com, example.co.uk)
+        if (domainParts.length === 3) {
+            const secondPart = domainParts[1];
+            const thirdPart = domainParts[2];
+            
+            // Define valid country TLD combinations
+            const validCountryTLDs = [
+                'co.uk', 'co.us', 'co.ca', 'co.au', 'co.nz', 'co.za', 'co.in', 'co.jp', 'co.kr', 'co.cn',
+                'com.au', 'com.br', 'com.mx', 'com.sg', 'com.hk', 'com.tw', 'com.my', 'com.ph', 'com.th',
+                'org.uk', 'org.au', 'org.nz', 'org.za', 'org.in', 'org.jp', 'org.kr', 'org.cn',
+                'net.uk', 'net.au', 'net.nz', 'net.za', 'net.in', 'net.jp', 'net.kr', 'net.cn',
+                'edu.au', 'edu.nz', 'edu.za', 'edu.in', 'edu.jp', 'edu.kr', 'edu.cn',
+                'gov.uk', 'gov.au', 'gov.nz', 'gov.za', 'gov.in', 'gov.jp', 'gov.kr', 'gov.cn'
+            ];
+            
+            // This should be checked FIRST to allow both example.co.uk and sub.example.co.uk
+            const countryTLD = secondPart + '.' + thirdPart;
+            if (validCountryTLDs.includes(countryTLD)) {
+                // This is valid: sub.example.co.uk, example.co.uk
+                return true;
+            }
+            
+            // Reject: example.com.com, example.org.com, example.com.org
+            if (commonTLDs.includes(secondPart) && commonTLDs.includes(thirdPart)) {
+                return false;
+            }
+            
+            // Allow valid subdomain patterns: sub.example.com, mail.example.org
+            if (commonTLDs.includes(thirdPart)) {
+                return true;
+            }
+            
+            return false;
+        }
+        
+        // Handle 4-part domains (e.g., sub.example.co.uk, sub.example.com.au)
+        if (domainParts.length === 4) {
+            const thirdPart = domainParts[2];
+            const fourthPart = domainParts[3];
+            
+            // Define valid country TLD combinations
+            const validCountryTLDs = [
+                'co.uk', 'co.us', 'co.ca', 'co.au', 'co.nz', 'co.za', 'co.in', 'co.jp', 'co.kr', 'co.cn',
+                'com.au', 'com.br', 'com.mx', 'com.sg', 'com.hk', 'com.tw', 'com.my', 'com.ph', 'com.th',
+                'org.uk', 'org.au', 'org.nz', 'org.za', 'org.in', 'org.jp', 'org.kr', 'org.cn',
+                'net.uk', 'net.au', 'net.nz', 'net.za', 'net.in', 'net.jp', 'net.kr', 'net.cn',
+                'edu.au', 'edu.nz', 'edu.za', 'edu.in', 'edu.jp', 'edu.kr', 'edu.cn',
+                'gov.uk', 'gov.au', 'gov.nz', 'gov.za', 'gov.in', 'gov.jp', 'gov.kr', 'gov.cn'
+            ];
+
+            const lastTwoParts = thirdPart + '.' + fourthPart;
+            
+            // If the last two parts form a valid country TLD, this is a valid subdomain
+            if (validCountryTLDs.includes(lastTwoParts)) {
+                return true;
+            }
+            
+            // Check for invalid double TLD patterns in the last three parts
+            if (commonTLDs.includes(thirdPart) && commonTLDs.includes(fourthPart)) {
+                return false;
+            }
+            
+            // Allow valid subdomain patterns where the last part is a TLD
+            if (commonTLDs.includes(fourthPart)) {
+                return true;
+            }
+            
+            return false;
+            }
+
+        if (email.length > 100) {
+            return localPart.length > 0 && 
+                   domainPart.length > 0 && 
+                   domainPart.includes('.') &&
+                   !localPart.startsWith('.') && 
+                   !localPart.endsWith('.') &&
+                   !domainPart.startsWith('.') && 
+                   !domainPart.endsWith('.') &&
+                   !localPart.includes('..') &&
+                   !domainPart.includes('..') &&
+                   !domainPart.startsWith('-') &&
+                   !domainPart.endsWith('-');
+        }
+        
+        // Regex validation for shorter emails
         return emailRegex.test(email);
     }
 

--- a/src/utils/emailTLDs.ts
+++ b/src/utils/emailTLDs.ts
@@ -1,0 +1,10 @@
+export const COMMON_TLDS = ['com', 'org', 'net', 'edu', 'gov', 'mil', 'int'];
+
+export const VALID_COUNTRY_TLDS = [
+  'co.uk', 'co.us', 'co.ca', 'co.au', 'co.nz', 'co.za', 'co.in', 'co.jp', 'co.kr', 'co.cn',
+  'com.au', 'com.br', 'com.mx', 'com.sg', 'com.hk', 'com.tw', 'com.my', 'com.ph', 'com.th',
+  'org.uk', 'org.au', 'org.nz', 'org.za', 'org.in', 'org.jp', 'org.kr', 'org.cn',
+  'net.uk', 'net.au', 'net.nz', 'net.za', 'net.in', 'net.jp', 'net.kr', 'net.cn',
+  'edu.au', 'edu.nz', 'edu.za', 'edu.in', 'edu.jp', 'edu.kr', 'edu.cn',
+  'gov.uk', 'gov.au', 'gov.nz', 'gov.za', 'gov.in', 'gov.jp', 'gov.kr', 'gov.cn'
+];


### PR DESCRIPTION

- Double .com -> reject
- Double TLD .org.com -> reject
- Double TLD .com.org -> reject
- Double TLD .net.com -> reject
- No TLD -> reject
- Single character TLD -> reject
- Invalid TLD -> reject
- Domain part ending with hyphen
- Domain part starting with hyphen
- Valid hyphen in middle of domain part
- Consecutive dots in domain
- Domain starting with dot
- Domain ending with dot
- Domain part too long (>253 chars)
- Empty string -> reject
- Null value -> reject
- Undefined value -> reject
- Space in Domain -> reject