### PR TITLE
not checking wsclient of ai to avoid crash

### DIFF
--- a/backend/serviceWs/roomutils.service.js
+++ b/backend/serviceWs/roomutils.service.js
@@ -67,6 +67,9 @@ class RoomUtilsService {
 	static async setPlayerAcceptance(room, playerId, acceptance) {
 
 		for (let p of room.players) {
+			if (p.ai === true) {
+				continue ;
+			}
 			if (p.wsclient.userId === playerId) {
 				if (acceptance == "accept" || acceptance == "accepted" || acceptance == "accepts") {
 					p.accepted = "accepted";


### PR DESCRIPTION
closes #160 

now backend doesn't crash anymore due to invalid element checking

BUT
there's still another error when starting a tournament with 3 people: after all 2 invited people answer "accept", everybody is moved to the game page, but is stuck on "waiting for players"-screen
<img width="1864" height="855" alt="image" src="https://github.com/user-attachments/assets/1311f3cb-5382-4929-a645-f9570b98a6c4" />
