### PR TITLE
add ca cert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ welcome-message:
 
 invite-message:
 	@IP=$$(ip -4 addr show scope global | grep inet | awk '{print $$2}' | cut -d/ -f1 | head -n1); \
-	echo "🌐 $(CYAN)Share this link with your friends:$(RESET) http://$${IP}:5173"
+	echo "🌐 $(CYAN)Share this link with your friends:$(RESET) https://$${IP}:5173"
 
 # ## START UP commands
 

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,11 @@ start-up-elk: check_env down-elk
 start-up-app: down-app setup-db check_env setup-certs invite-message
 	@echo "$(CYAN)🚀 LET'S MAKE APP UP 🚀$(RESET)"
 	@echo "$(YELLOW)🏗  spinning up container...$(RESET)"
-	@docker compose up app --build -d > docker_build.log 2>&1
+	@docker compose up app nginx --build -d > docker_build.log 2>&1
 	@echo "$(GREEN)App has started up, let's get ponging!$(RESET)"
 
 restart-app:
-	@docker compose down app && docker compose up app -d
+	@docker compose down app nginx && docker compose up app nginx -d
 
 
 # ## down commands
@@ -42,7 +42,7 @@ down-elk:
 	@echo "$(GREEN)ELK was turned off!$(RESET)"
 
 down-app:
-	@docker compose down app
+	@docker compose down app nginx
 	@echo "$(GREEN)App was turned off!$(RESET)"
 
 down:

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ setup-certs:
 rm-certs:
 	@echo "$(MAGENTA)🧼 remove certs$(RESET)"
 	@rm -rf backend/ssl/server.*
+	@rm -rf backend/ssl/ca.*
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ welcome-message:
 
 invite-message:
 	@IP=$$(ip -4 addr show scope global | grep inet | awk '{print $$2}' | cut -d/ -f1 | head -n1); \
-	echo "🌐 $(CYAN)Share this link with your friends:$(RESET) https://$${IP}:5173"
+	echo "🌐 $(CYAN)Share this link with your friends:$(RESET) https://$${IP}"
 
 # ## START UP commands
 

--- a/backend/scripts/README.md
+++ b/backend/scripts/README.md
@@ -1,0 +1,55 @@
+# SSL Certificate Setup Guide
+
+This project uses a custom Certificate Authority (CA) to generate SSL certificates for local and LAN development.
+
+## 1. Generate Certificates
+
+Run the following command to generate the CA and server certificates:
+
+```bash
+make setup-certs
+```
+
+This will:
+- Create a CA certificate (`backend/ssl/ca.crt`)
+- Create a server certificate (`backend/ssl/server.crt`) and key (`backend/ssl/server.key`)
+- Add your computer's IP to the certificate's valid domains
+
+## 2. Trust the CA on your System
+
+To avoid browser warnings, you need to trust the CA certificate:
+
+```bash
+sudo cp backend/ssl/ca.crt /usr/local/share/ca-certificates/transcendence-ca.crt
+sudo update-ca-certificates
+```
+
+You may need to restart your browser or your system for changes to take effect.
+
+## 3. Trust the CA in Firefox
+
+On Linux, Firefox uses its own certificate store. To trust the CA in Firefox:
+
+1. Open Firefox and go to `about:preferences#privacy`
+2. Scroll down to "Certificates" and click "View Certificates"
+3. Go to the "Authorities" tab and click "Import"
+4. Select `backend/ssl/ca.crt`
+5. Check "Trust this CA to identify websites" and confirm
+
+Restart Firefox completely (close all windows, not just tabs).
+
+## 4. Access the Website
+
+You can now access your site securely at:
+
+```
+https://<your-ip>:5173
+```
+
+If you want to share access, others must also trust your CA certificate on their devices.
+
+---
+
+**Note:**  
+Never commit `.key` files to version control.  
+If you regenerate certificates, repeat the trust steps

--- a/backend/scripts/README.md
+++ b/backend/scripts/README.md
@@ -19,8 +19,17 @@ This will:
 
 To avoid browser warnings, you need to trust the CA certificate:
 
+**Method 1 (Standard):**
 ```bash
 sudo cp backend/ssl/ca.crt /usr/local/share/ca-certificates/transcendence-ca.crt
+sudo update-ca-certificates
+```
+
+**Method 2 (If Method 1 doesn't work - e.g., on VMs):**
+```bash
+sudo mkdir -p /usr/share/ca-certificates/extra
+sudo cp backend/ssl/ca.crt /usr/share/ca-certificates/extra/transcendence-ca.crt
+echo "extra/transcendence-ca.crt" | sudo tee -a /etc/ca-certificates.conf
 sudo update-ca-certificates
 ```
 

--- a/backend/scripts/generate-ssl.sh
+++ b/backend/scripts/generate-ssl.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
+
 # SSL Certificate Generator for Backend Development
-# This creates self-signed certificates for the backend server
+# This script creates a CA and uses it to sign a backend server certificate
 
 set -e
 
@@ -14,46 +15,99 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SSL_DIR="$SCRIPT_DIR/../ssl"
+CA_KEY="$SSL_DIR/ca.key"
+CA_CERT="$SSL_DIR/ca.crt"
+SERVER_KEY="$SSL_DIR/server.key"
+SERVER_CSR="$SSL_DIR/server.csr"
+SERVER_CERT="$SSL_DIR/server.crt"
 
 # Create SSL directory if it doesn't exist
 mkdir -p "$SSL_DIR" || { echo "❌ Error: Cannot create SSL directory"; exit 1; }
 
 # Check if certificates already exist and are valid
-if [[ -f "$SSL_DIR/server.crt" && -f "$SSL_DIR/server.key" ]]; then
-    if openssl x509 -in "$SSL_DIR/server.crt" -noout -checkend 86400 2>/dev/null; then
-        echo "✅ Valid certificates already exist"
+if [[ -f "$SERVER_CERT" && -f "$SERVER_KEY" && -f "$CA_CERT" && -f "$CA_KEY" ]]; then
+    if openssl x509 -in "$SERVER_CERT" -noout -checkend 86400 2>/dev/null; then
+        echo "✅ Valid certificates already exist (signed by CA)"
         read -p "Regenerate? (y/N): " -n 1 -r
         echo
         [[ ! $REPLY =~ ^[Yy]$ ]] && exit 0
     fi
 fi
 
-echo "🔐 Generating backend SSL certificates..."
+echo "🔐 Generating CA and backend SSL certificates..."
 
-# Generate self-signed certificate
-openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256 -keyout "$SSL_DIR/server.key" -out "$SSL_DIR/server.crt" \
-    -days 365 -nodes \
-    -subj "/C=US/ST=Development/L=Local/O=Transcendence/OU=Backend/CN=localhost" 2>/dev/null || {
-    echo "❌ Error: Certificate generation failed"
-    rm -f "$SSL_DIR/server.key" "$SSL_DIR/server.crt"
-    exit 1
-}
+# Get your computer's primary IPv4 address
+IP_ADDR=$(ip -4 addr show scope global | grep inet | awk '{print $2}' | cut -d/ -f1 | head -n1)
+
+# Create a temporary OpenSSL config with SAN for localhost and your IP
+SAN_CONFIG="$SSL_DIR/san.cnf"
+cat > "$SAN_CONFIG" <<EOF
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+[req_distinguished_name]
+[v3_req]
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = localhost
+IP.1 = $IP_ADDR
+EOF
+
+# 1. Generate CA key and certificate if not present
+if [[ ! -f "$CA_KEY" || ! -f "$CA_CERT" ]]; then
+    echo "🔑 Generating new CA private key and certificate..."
+    openssl req -x509 -newkey rsa:4096 -days 1825 -nodes \
+        -keyout "$CA_KEY" -out "$CA_CERT" \
+        -subj "/C=AT/ST=Vienna/L=Vienna/O=Transcendence/OU=DevCA/CN=TranscendenceDevCA" 2>/dev/null || {
+        echo "❌ Error: CA certificate generation failed"
+        rm -f "$CA_KEY" "$CA_CERT"
+        exit 1
+    }
+    chmod 600 "$CA_KEY"
+    chmod 644 "$CA_CERT"
+    echo "✅ CA certificate generated: $CA_CERT"
+fi
+
+# 2. Generate server key and CSR
+echo "🔑 Generating server private key and CSR..."
+openssl ecparam -genkey -name prime256v1 -out "$SERVER_KEY" 2>/dev/null || {
+    echo "❌ Error: Server key generation failed"; rm -f "$SERVER_KEY"; exit 1; }
+openssl req -new -key "$SERVER_KEY" -out "$SERVER_CSR" \
+    -subj "/C=AT/ST=Vienna/L=Vienna/O=Transcendence/OU=Backend/CN=localhost" \
+    -config "$SAN_CONFIG" -reqexts v3_req 2>/dev/null || {
+    echo "❌ Error: CSR generation failed"; rm -f "$SERVER_KEY" "$SERVER_CSR"; exit 1; }
+
+# 3. Sign server CSR with CA (include SAN)
+echo "🖋️  Signing server certificate with CA..."
+openssl x509 -req -in "$SERVER_CSR" -CA "$CA_CERT" -CAkey "$CA_KEY" -CAcreateserial \
+    -out "$SERVER_CERT" -days 365 -sha256 -extfile "$SAN_CONFIG" -extensions v3_req 2>/dev/null || {
+    echo "❌ Error: Server certificate signing failed"; rm -f "$SERVER_KEY" "$SERVER_CERT" "$SERVER_CSR"; exit 1; }
+rm -f "$SERVER_CSR" "$SSL_DIR/ca.srl" "$SAN_CONFIG"
 
 # Set permissions
-chmod 600 "$SSL_DIR/server.key" 2>/dev/null || echo "⚠️  Warning: Cannot set key permissions"
-chmod 644 "$SSL_DIR/server.crt" 2>/dev/null || echo "⚠️  Warning: Cannot set cert permissions"
+chmod 600 "$SERVER_KEY" 2>/dev/null || echo "⚠️  Warning: Cannot set key permissions"
+chmod 644 "$SERVER_CERT" 2>/dev/null || echo "⚠️  Warning: Cannot set cert permissions"
 
 # Validate certificates
-openssl x509 -in "$SSL_DIR/server.crt" -noout -text &>/dev/null || {
-    echo "❌ Error: Invalid certificate generated"
-    rm -f "$SSL_DIR/server.key" "$SSL_DIR/server.crt"
+openssl x509 -in "$SERVER_CERT" -noout -text &>/dev/null || {
+    echo "❌ Error: Invalid server certificate generated"
+    rm -f "$SERVER_KEY" "$SERVER_CERT"
+    exit 1
+}
+openssl x509 -in "$CA_CERT" -noout -text &>/dev/null || {
+    echo "❌ Error: Invalid CA certificate generated"
+    rm -f "$CA_KEY" "$CA_CERT"
     exit 1
 }
 
-echo "✅ Backend SSL certificates generated successfully!"
-echo "   Certificate: $SSL_DIR/server.crt"
-echo "   Private Key: $SSL_DIR/server.key"
-echo "   Expires: $(openssl x509 -in "$SSL_DIR/server.crt" -noout -enddate | sed 's/notAfter=//')"
+echo "✅ Backend SSL certificates generated and signed by CA!"
+echo "   Server Certificate: $SERVER_CERT"
+echo "   Server Private Key: $SERVER_KEY"
+echo "   CA Certificate: $CA_CERT"
+echo "   Expires: $(openssl x509 -in "$SERVER_CERT" -noout -enddate | sed 's/notAfter=//')"
 echo ""
-echo "⚠️  Development certificates only - browsers will show warnings"
-echo "🔒 Private key (.key) should NOT be committed to git"
+echo "⚠️  To trust this CA on your system, run:"
+echo "   sudo cp $CA_CERT /usr/local/share/ca-certificates/transcendence-ca.crt && sudo update-ca-certificates"
+echo "   (You may need to restart your browser/system for changes to take effect)"
+echo ""
+echo "🔒 Private keys (.key) should NOT be committed to git"

--- a/backend/scripts/generate-ssl.sh
+++ b/backend/scripts/generate-ssl.sh
@@ -44,6 +44,8 @@ if [[ -z "$IP_ADDR" ]]; then
     echo "❌ Error: Unable to determine the primary IPv4 address."
     echo "   Ensure your network interface is up and has an assigned IP address."
     exit 1
+else
+    echo "✅ Detected primary IPv4 address: $IP_ADDR"
 fi
 
 

--- a/backend/scripts/generate-ssl.sh
+++ b/backend/scripts/generate-ssl.sh
@@ -39,6 +39,14 @@ echo "🔐 Generating CA and backend SSL certificates..."
 # Get your computer's primary IPv4 address
 IP_ADDR=$(ip -4 addr show scope global | grep inet | awk '{print $2}' | cut -d/ -f1 | head -n1)
 
+# Check if IP_ADDR is empty
+if [[ -z "$IP_ADDR" ]]; then
+    echo "❌ Error: Unable to determine the primary IPv4 address."
+    echo "   Ensure your network interface is up and has an assigned IP address."
+    exit 1
+fi
+
+
 # Create a temporary OpenSSL config with SAN for localhost and your IP
 SAN_CONFIG="$SSL_DIR/san.cnf"
 cat > "$SAN_CONFIG" <<EOF

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
       dockerfile: Dockerfile
     ports:
       - "5173:5173"  # Expose to host
-      # - "3000:3000"  # http backend
       # - "3443:3443"  # https backend
     environment:
       - NODE_ENV=production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       dockerfile: Dockerfile
     ports:
       - "5173:5173"  # Expose to host
-      - "3000:3000"  # http backend
-      - "3443:3443"  # https backend
+      # - "3000:3000"  # http backend
+      # - "3443:3443"  # https backend
     environment:
       - NODE_ENV=production
       - LOG_PATH_BE=${LOG_PATH_BE}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,10 @@
 
 services:
+
   app:
     build:
       context: .
       dockerfile: Dockerfile
-    ports:
-      - "5173:5173"  # Expose to host
-      # - "3443:3443"  # https backend
     environment:
       - NODE_ENV=production
       - LOG_PATH_BE=${LOG_PATH_BE}
@@ -24,6 +22,20 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "443:443"   # HTTPS only
+      - "80:80"     # HTTP redirect to HTTPS
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./backend/ssl/server.crt:/etc/ssl/certs/server.crt:ro
+      - ./backend/ssl/server.key:/etc/ssl/private/server.key:ro
+    depends_on:
+      - app
+    networks:
+      - transcendence_net
 
   setup:
     image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,75 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    # WebSocket upgrade mapping
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
+    upstream backend {
+        server app:3443;
+    }
+
+    upstream frontend {
+        server app:5173;
+    }
+
+    # HTTP server - redirect to HTTPS
+    server {
+        listen 80;
+        server_name _;
+        return 301 https://$host$request_uri;
+    }
+
+    # HTTPS server
+    server {
+        listen 443 ssl;
+        server_name _;
+
+        ssl_certificate /etc/ssl/certs/server.crt;
+        ssl_certificate_key /etc/ssl/private/server.key;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+
+        # Frontend (main application) with WebSocket support for Vite HMR
+        location / {
+            proxy_pass https://frontend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_ssl_verify off;
+            
+            # Support WebSocket upgrades (for Vite HMR)
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+        }
+
+        # API endpoints - proxy to backend
+        location /api/ {
+            proxy_pass https://backend/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_ssl_verify off;
+        }
+
+        # WebSocket endpoint - secure wss:// connection as required
+        location /hello-ws {
+            proxy_pass https://backend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_ssl_verify off;
+        }
+    }
+}

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -2,16 +2,17 @@
 // Detect if we're using SSL based on the current page protocol
 const isSSL = typeof window !== 'undefined' && window.location.protocol === 'https:';
 const wsProtocol = isSSL ? 'wss:' : 'ws:';
-const defaultPort = isSSL ? '3443' : '3000';
 
 // Determine WebSocket URL based on environment
 const getDefaultWsUrl = () => {
-  // In development with Vite proxy, use relative path
-  if (import.meta.env.DEV) {
-    return '/ws';
-  }
-  // In production or direct connection, use full URL
-  return `${wsProtocol}//${window.location.hostname}:${defaultPort}`;
+  // Use the same host as the current page (nginx proxy)
+  // This connects to wss://hostname/hello-ws through the nginx proxy
+  const baseUrl = typeof window !== 'undefined' 
+    ? `${wsProtocol}//${window.location.host}` 
+    : `${wsProtocol}//localhost`;
+  
+  console.log('Using secure WebSocket URL via nginx proxy:', baseUrl);
+  return baseUrl;
 };
 
 const API_CONFIG = {


### PR DESCRIPTION
# description:

creating our own Certificate Authority (CA) comes with extra steps, but at the advantage of not having to expose our backend to the public. amazing security step.

also you won't encounter the "untrusted cert, trust anyways" site again.

# downsides:

the downsides are the extra steps detailed in the README.md, strongly advise to read it. it is necessary for all devices entering our website to add our ca.crt manually to the trust-store of the system or the browser.

another downside, that i didn't mention in the readme, that the script and the steps in readme **might** be OS-dependent. I am working on ubuntu, and my VM at campus is also ubuntu, so chances are good it will work on campus. but for you testing, it might be even more extra steps, if your OS is acting different from ubuntu. 

# why do this?

the main reason for keeping the :3443 backend port exposed was to ensure that the websocket connection can be made. so far this is a manual step, you have to visit localhost:3443 in your browser and accept the certificate. but exposing the port, also exposes our API endpoints (and of course also our websocket endpoint). this is ... very bad, and something that has bothered me for a good while. but this PR solves it!

# potential sidesteps

in this PR I also deactivate the exposition of the backend ports :3000 and :3443. if you cannot make this work on your machine, or in the case of quick testing on other devices, like your phone or tablet, just _**expose :3443 again**_. this is also what i intend to do during evaluation, if we want to demonstrate playing a remote match from two different devices. you can do that by uncommenting line 9 in docker-compose.yml

<img width="407" height="223" alt="image" src="https://github.com/user-attachments/assets/eba4115e-6674-4110-aae7-8b20974daacb" />

# result

<img width="524" height="307" alt="image" src="https://github.com/user-attachments/assets/fbc22bbb-894a-4208-b136-dc270f9211b1" />
